### PR TITLE
Update dotnet test command to include a logger for test results

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -73,7 +73,7 @@ jobs:
 
     # Execute all unit tests in the solution
     - name: Execute unit tests
-      run: dotnet test --logger "trx;LogFileName=test-results.trx"
+      run: dotnet test --logger "trx;LogFileName=test-results/test-results.trx"
 
     - name: Publish Test Results
       uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -80,6 +80,4 @@ jobs:
       if: always()
       with:
         files: |
-          test-results/**/*.xml
-          test-results/**/*.trx
-          test-results/**/*.json
+          /**/*.trx

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -50,7 +50,7 @@ jobs:
 
     strategy:
       matrix:
-        configuration: [Debug, Release]
+        configuration: [Debug]
 
     runs-on: ubuntu-latest  # For a list of available runner types, refer to
                              # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -73,7 +73,7 @@ jobs:
 
     # Execute all unit tests in the solution
     - name: Execute unit tests
-      run: dotnet test
+      run: dotnet test --logger "trx;LogFileName=test-results.trx"
 
     - name: Publish Test Results
       uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -80,4 +80,4 @@ jobs:
       if: always()
       with:
         files: |
-          /**/*.trx
+          **/*.trx

--- a/.gitignore
+++ b/.gitignore
@@ -400,3 +400,5 @@ FodyWeavers.xsd
 .idea/
 
 *.DotSettings.user
+
+**/test-results/


### PR DESCRIPTION
This pull request includes a change to the `dotnet-desktop.yml` workflow file. The change modifies the `Execute unit tests` job to include a logger in the `dotnet test` command. This will produce test results in the `trx` format, which can be published in subsequent steps.

* [`.github/workflows/dotnet-desktop.yml`](diffhunk://#diff-1141f91ae004c9af379b5cb74bcb73f8594024a47c044c05df2fe6e2547c6585L76-R76): Modified the `dotnet test` command in the `Execute unit tests` job to include a logger that outputs test results in the `trx` format.